### PR TITLE
fix(FEC-10225): floating player doesn't works during pre-roll Ad

### DIFF
--- a/src/visibility.js
+++ b/src/visibility.js
@@ -27,7 +27,7 @@ class Visibility extends BasePlugin {
   _floatingContainer: HTMLElement | null;
   _floatingPoster: HTMLElement | null;
   _observer: window.IntersectionObserver;
-  _everStartedPlaying: boolean = false;
+  _playbackStartOccurred: boolean = false;
   _dismissed: boolean = false;
   _isInPIP: boolean = false;
 
@@ -129,7 +129,7 @@ class Visibility extends BasePlugin {
 
   _handleVisibilityChange(entries: Array<window.IntersectionObserverEntry>) {
     const playerIsOutOfVisibility = entries[0].intersectionRatio < this.config.threshold / 100;
-    if (this.config.floating && this._everStartedPlaying && !this._dismissed && !this._isInPIP) {
+    if (this.config.floating && this._playbackStartOccurred && !this._dismissed && !this._isInPIP) {
       this._handleFloatingChange(playerIsOutOfVisibility);
     }
   }
@@ -154,8 +154,8 @@ class Visibility extends BasePlugin {
     this.eventManager.listen(this.player, this.player.Event.LEAVE_PICTURE_IN_PICTURE, () => {
       this._isInPIP = false;
     });
-    this.eventManager.listen(this.player, this.player.Event.FIRST_PLAYING, () => {
-      this._everStartedPlaying = true;
+    this.eventManager.listen(this.player, this.player.Event.PLAYBACK_START, () => {
+      this._playbackStartOccurred = true;
       Utils.Dom.setStyle(this._floatingPoster, 'background-image', `url("${this.player.config.sources.poster}")`);
     });
   }


### PR DESCRIPTION
### Description of the Changes

Floating should happen when user has scrolled out after ever engaging the player.
Engaging - as in attempted viewing it.
Therefore playback_start better represent this state then first_playing

Solves FEC-10225

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
