### PR TITLE
fix(FEC-10230): custom 'div' tag located over floating player

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -26,6 +26,7 @@
   width: 100%;
 }
 .playkit-floating-container.playkit-floating-active {
+  z-index: 9999;
   position: fixed;
 }
 


### PR DESCRIPTION
### Description of the Changes

added z-index to avoid other elements covering the floating player

Solves FEC-10230

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
