### PR TITLE
fix(FEC-10355): floating poster is much bigger than video size

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -5,19 +5,21 @@
   background-repeat: no-repeat;
   background-size: contain;
   background-position: center;
-  position: absolute;
+  display: none;
 }
-
-.playkit-floating-active-top {
+.playkit-floating-poster.playkit-floating-poster-show {
+  display: block;
+}
+.playkit-floating-active.playkit-floating-active-top {
   top: 0;
 }
-.playkit-floating-active-bottom {
+.playkit-floating-active.playkit-floating-active-bottom {
   bottom: 0;
 }
-.playkit-floating-active-left {
+.playkit-floating-active.playkit-floating-active-left {
   left: 0;
 }
-.playkit-floating-active-right {
+.playkit-floating-active.playkit-floating-active-right {
   right: 0;
 }
 

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -10,6 +10,7 @@ const FLOATING_DRAGGABLE_CLASS: string = 'playkit-floating-draggable';
 const FLOATING_ACTIVE_CLASS: string = 'playkit-floating-active';
 const FLOATING_CONTAINER_CLASS: string = 'playkit-floating-container';
 const FLOATING_POSTER_CLASS: string = 'playkit-floating-poster';
+const FLOATING_POSTER_CLASS_SHOW: string = 'playkit-floating-poster-show';
 const DEFUALT_FLOATING_CONFIG = {
   floating: {
     position: 'bottom-right',
@@ -126,6 +127,7 @@ class Visibility extends BasePlugin {
   }
 
   _stopFloating() {
+    Utils.Dom.removeClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
     Utils.Dom.removeClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
     Utils.Dom.removeAttribute(this._floatingContainer, 'style');
     if (this.config.floating.draggable) {
@@ -138,6 +140,7 @@ class Visibility extends BasePlugin {
 
   _startFloating() {
     Utils.Dom.addClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
+    Utils.Dom.addClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
     Utils.Dom.setStyle(this._floatingContainer, 'height', this.config.floating.height + 'px');
     Utils.Dom.setStyle(this._floatingContainer, 'width', this.config.floating.width + 'px');
     Utils.Dom.setStyle(this._floatingContainer, 'margin', `${this.config.floating.marginY}px ${this.config.floating.marginX}px`);


### PR DESCRIPTION
### Description of the Changes

Poster was position: absolute and its size only fit when video container had position: relative.
Position absolute was removed (was needed to keep the poster under the video) - instead the poster is hidden until floating is active.
In addition - I noticed the floating fixed positions were applied on the container even if floating was not active - this didn't effect the functionality as there was no position: fixed applied together but it is not correct. 

Solves FEC-10355

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
