### PR TITLE
fix(FEC-10709): unObserve of viewability manager threw error

### DIFF
--- a/src/visibility.js
+++ b/src/visibility.js
@@ -187,10 +187,10 @@ class Visibility extends BasePlugin {
     this.logger.debug('destroy');
     Utils.Dom.removeChild(this._appTargetContainer, this._floatingContainer);
     Utils.Dom.removeChild(this._appTargetContainer, this._floatingPoster);
+    this.player.viewabilityManager.unObserve(this._appTargetContainer, this._handleViewabilityChanged.bind(this));
     this._appTargetContainer = null;
     this._floatingContainer = null;
     this._floatingPoster = null;
-    this.player.viewabilityManager.unObserve(this._appTargetContainer, this._handleViewabilityChanged.bind(this));
     this.eventManager.destroy();
   }
 


### PR DESCRIPTION
was done on a null element. Should move before cleaning this._appTargetContainer

Solves FEC-10709

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
