### PR TITLE
feat(FEC-13662): apply new design for dismissing floating player

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Finally, add the bundle as a script tag in your page, and initialize the player
     var config = {
      ...
      plugins: {
-       visibility: {
+       floating: {
        }
      }
      ...

--- a/src/components/dismissible/dismissible.js
+++ b/src/components/dismissible/dismissible.js
@@ -15,24 +15,27 @@ class DismissibleFloatingButtonComponent extends Component {
   render(props: any) {
     return (
       <Localizer>
-        <a
-          role="button"
-          ref={el => {
-            if (props.addAccessibleChild) {
-              props.addAccessibleChild(el);
-            }
-          }}
-          tabIndex="0"
-          onClick={() => props.onClose()}
-          onKeyDown={e => {
-            if (e.keyCode === KeyMap.ENTER) {
-              props.onClose();
-            }
-          }}
-          aria-label={<Text id="overlay.close" />}
-          className={'playkit-floating-dismissible playkit-icon playkit-icon-close'}>
-          <Icon type={IconType.Close} />
-        </a>
+        <div id={'playkit-floating-dismissible-container'}>
+          <div className={'playkit-dismissible-text'}>Back to player</div>
+          <a
+            role="button"
+            ref={el => {
+              if (props.addAccessibleChild) {
+                props.addAccessibleChild(el);
+              }
+            }}
+            tabIndex="0"
+            onClick={() => props.onClose()}
+            onKeyDown={e => {
+              if (e.keyCode === KeyMap.ENTER) {
+                props.onClose();
+              }
+            }}
+            aria-label={<Text id="overlay.close" />}
+            className={'playkit-floating-dismissible playkit-icon playkit-icon-close'}>
+            <Icon type={IconType.Close} />
+          </a>
+        </div>
       </Localizer>
     );
   }

--- a/src/components/dismissible/dismissible.js
+++ b/src/components/dismissible/dismissible.js
@@ -11,28 +11,45 @@ const {Component} = preact;
 const {KeyMap} = utils;
 const {Icon, IconType} = Components;
 
-class DismissibleFloatingButtonComponent extends Component {
+type DismissibleProps = {
+  onClose: (shouldScrollToPlayer: boolean) => void
+};
+
+class DismissibleFloatingButtonComponent extends Component<DismissibleProps> {
+  _onKeyDownHandler(e: KeyboardEvent, shouldScrollToPlayer = false): void {
+    if (e.keyCode === KeyMap.ENTER) {
+      this.props.onClose(shouldScrollToPlayer);
+    }
+  }
+
   render(props: any) {
+    const sharedProps = {
+      role: 'button',
+      tabIndex: '0',
+      ref: el => {
+        if (props.addAccessibleChild) {
+          props.addAccessibleChild(el);
+        }
+      }
+    };
+
     return (
       <div id={'playkit-floating-dismissible-container'}>
         <Localizer>
-          <div className={'playkit-dismissible-text'}>{<Text id="floating.back_to_video">Back to video</Text>}</div>
+          <div
+            {...sharedProps}
+            className={'playkit-dismissible-text'}
+            onClick={() => props.onClose(true)}
+            onKeyDown={e => this._onKeyDownHandler(e, true)}
+            aria-label={<Text id="floating.back_to_video">Back to video</Text>}>
+            {<Text id="floating.back_to_video">Back to video</Text>}
+          </div>
         </Localizer>
         <Localizer>
           <a
-            role="button"
-            ref={el => {
-              if (props.addAccessibleChild) {
-                props.addAccessibleChild(el);
-              }
-            }}
-            tabIndex="0"
+            {...sharedProps}
             onClick={() => props.onClose()}
-            onKeyDown={e => {
-              if (e.keyCode === KeyMap.ENTER) {
-                props.onClose();
-              }
-            }}
+            onKeyDown={e => this._onKeyDownHandler(e)}
             aria-label={<Text id="overlay.close" />}
             className={'playkit-floating-dismissible playkit-icon playkit-icon-close'}>
             <Icon type={IconType.Close} />

--- a/src/components/dismissible/dismissible.js
+++ b/src/components/dismissible/dismissible.js
@@ -15,7 +15,9 @@ class DismissibleFloatingButtonComponent extends Component {
   render(props: any) {
     return (
       <div id={'playkit-floating-dismissible-container'}>
-        <div className={'playkit-dismissible-text'}>Back to player</div>
+        <Localizer>
+          <div className={'playkit-dismissible-text'}>{<Text id="floating.back_to_video">Back to video</Text>}</div>
+        </Localizer>
         <Localizer>
           <a
             role="button"

--- a/src/components/dismissible/dismissible.js
+++ b/src/components/dismissible/dismissible.js
@@ -14,9 +14,9 @@ const {Icon, IconType} = Components;
 class DismissibleFloatingButtonComponent extends Component {
   render(props: any) {
     return (
-      <Localizer>
-        <div id={'playkit-floating-dismissible-container'}>
-          <div className={'playkit-dismissible-text'}>Back to player</div>
+      <div id={'playkit-floating-dismissible-container'}>
+        <div className={'playkit-dismissible-text'}>Back to player</div>
+        <Localizer>
           <a
             role="button"
             ref={el => {
@@ -35,8 +35,8 @@ class DismissibleFloatingButtonComponent extends Component {
             className={'playkit-floating-dismissible playkit-icon playkit-icon-close'}>
             <Icon type={IconType.Close} />
           </a>
-        </div>
-      </Localizer>
+        </Localizer>
+      </div>
     );
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -37,14 +37,42 @@
   cursor: grab;
 }
 
+#playkit-floating-dismissible-container {
+  display: none;
+  align-items: center;
+  flex-direction: row;
+  width: 100%;
+  height: 32px;
+  background: #242424;
+  border-radius: 8px 8px 0 0;
+  .playkit-dismissible-text {
+    color: white;
+    display: flex;
+    width: 100%;
+    margin-left: 8px;
+    font-size: 14px;
+    font-weight: 700;
+    font-family: Lato, Helvetica Neue, Segoe UI, sans-serif;
+    cursor: default;
+  }
+  .playkit-icon-close {
+    margin-right: 8px;
+    cursor: pointer;
+    background-position-x: 0;
+  }
+}
+
 .playkit-floating-dismissible {
   display: none;
   height: 24px;
   width: 24px;
 }
 
-.playkit-floating-container.playkit-floating-active .playkit-floating-dismissible {
-  display: inline-block;
+.playkit-floating-container.playkit-floating-active #playkit-floating-dismissible-container {
+  display: flex;
+  .playkit-floating-dismissible {
+    display: flex;
+  }
 }
 .playkit-floating-dismissible.playkit-floating-infullscreen{
   display: none !important;

--- a/src/style.css
+++ b/src/style.css
@@ -30,12 +30,12 @@
   touch-action: none;
   display: flex;
   flex-direction: column;
-  border-radius: 8px;
   overflow: hidden;
 }
 .playkit-floating-container.playkit-floating-active {
   z-index: 9999;
   position: fixed;
+  border-radius: 8px;
 }
 .playkit-floating-container.playkit-floating-active.draggable {
   cursor: grab;

--- a/src/style.css
+++ b/src/style.css
@@ -30,6 +30,8 @@
   touch-action: none;
   display: flex;
   flex-direction: column;
+  border-radius: 8px;
+  overflow: hidden;
 }
 .playkit-floating-container.playkit-floating-active {
   z-index: 9999;

--- a/src/style.css
+++ b/src/style.css
@@ -57,10 +57,9 @@
     font-size: 14px;
     font-weight: 700;
     font-family: Lato, Helvetica Neue, Segoe UI, sans-serif;
-    cursor: default;
+    cursor: pointer;
   }
   .playkit-icon-close {
-    margin-right: 8px;
     cursor: pointer;
     background-position-x: 0;
   }
@@ -76,6 +75,8 @@
   display: flex;
   .playkit-floating-dismissible {
     display: flex;
+    align-items: center;
+    margin: 4px 8px 4px 0;
   }
 }
 .playkit-floating-dismissible.playkit-floating-infullscreen{

--- a/src/style.css
+++ b/src/style.css
@@ -28,6 +28,8 @@
   height: 100%;
   width: 100%;
   touch-action: none;
+  display: flex;
+  flex-direction: column;
 }
 .playkit-floating-container.playkit-floating-active {
   z-index: 9999;

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -12,9 +12,10 @@ const FLOATING_CONTAINER_CLASS: string = 'playkit-floating-container';
 const FLOATING_POSTER_CLASS: string = 'playkit-floating-poster';
 const FLOATING_POSTER_CLASS_SHOW: string = 'playkit-floating-poster-show';
 const FLOATING_DISMISSIBLE_CONTAINER_ID: string = 'playkit-floating-dismissible-container';
+const DISMISSIBLE_CONTAINER_HEIGHT: number = 32;
 const DEFAULT_FLOATING_CONFIG: FloatingConfigObject = {
   position: 'bottom-right',
-  height: '257',
+  height: '225',
   width: '400',
   marginX: '20',
   marginY: '20',
@@ -36,6 +37,7 @@ class Visibility extends BasePlugin {
   _isInPIP: boolean = false;
   _currMousePos: {x: number, y: number} = {x: 0, y: 0};
   _throttleWait: boolean = false;
+  _floatingContainerHeight: string;
 
   /**
    * The default configuration of the plugin.
@@ -106,6 +108,8 @@ class Visibility extends BasePlugin {
     if (this.config.draggable) {
       Utils.Dom.addClassName(this._floatingContainer, FLOATING_DRAGGABLE_CLASS);
     }
+
+    this._floatingContainerHeight = this.config.dismissible ? `${Number(this.config.height) + DISMISSIBLE_CONTAINER_HEIGHT}` : this.config.height;
   }
 
   _handleDismissFloating() {
@@ -131,7 +135,7 @@ class Visibility extends BasePlugin {
   _startFloating() {
     Utils.Dom.addClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
     Utils.Dom.addClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
-    Utils.Dom.setStyle(this._floatingContainer, 'height', this.config.height + 'px');
+    Utils.Dom.setStyle(this._floatingContainer, 'height', `${this._floatingContainerHeight}px`);
     Utils.Dom.setStyle(this._floatingContainer, 'width', this.config.width + 'px');
     Utils.Dom.setStyle(this._floatingContainer, 'margin', `${this.config.marginY}px ${this.config.marginX}px`);
     if (this.config.dismissible) {

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -11,6 +11,7 @@ const FLOATING_ACTIVE_CLASS: string = 'playkit-floating-active';
 const FLOATING_CONTAINER_CLASS: string = 'playkit-floating-container';
 const FLOATING_POSTER_CLASS: string = 'playkit-floating-poster';
 const FLOATING_POSTER_CLASS_SHOW: string = 'playkit-floating-poster-show';
+const FLOATING_DISMISSIBLE_CONTAINER_ID: string = 'playkit-floating-dismissible-container';
 const DEFAULT_FLOATING_CONFIG: FloatingConfigObject = {
   position: 'bottom-right',
   height: '225',
@@ -93,7 +94,7 @@ class Visibility extends BasePlugin {
     this._floatingContainer.className = FLOATING_CONTAINER_CLASS;
 
     Utils.Dom.prependTo(this._floatingPoster, this._appTargetContainer);
-    let kalturaPlayerContainer = Utils.Dom.getElementById(this.player.config.ui.targetId);
+    const kalturaPlayerContainer = Utils.Dom.getElementById(this.player.config.ui.targetId);
     if (this._appTargetContainer && this._floatingContainer) {
       this._appTargetContainer.replaceChild(this._floatingContainer, kalturaPlayerContainer);
       Utils.Dom.appendChild(this._floatingContainer, kalturaPlayerContainer);
@@ -110,6 +111,7 @@ class Visibility extends BasePlugin {
   _handleDismissFloating() {
     this._dismissed = true;
     this.player.pause();
+    this._floatingPoster.scrollIntoView();
     this._stopFloating();
     this.dispatchEvent(EventType.FLOATING_PLAYER_DISMISSED);
   }
@@ -132,6 +134,10 @@ class Visibility extends BasePlugin {
     Utils.Dom.setStyle(this._floatingContainer, 'height', this.config.height + 'px');
     Utils.Dom.setStyle(this._floatingContainer, 'width', this.config.width + 'px');
     Utils.Dom.setStyle(this._floatingContainer, 'margin', `${this.config.marginY}px ${this.config.marginX}px`);
+    if (this.config.dismissible) {
+      const dismissibleContainerEl = Utils.Dom.getElementById(FLOATING_DISMISSIBLE_CONTAINER_ID);
+      this._floatingContainer.prepend(dismissibleContainerEl);
+    }
     if (this.config.draggable) {
       this.eventManager.listen(this._floatingContainer, 'mousedown', e => {
         this._startDrag(e, 'mousemove', 'mouseup');

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -14,7 +14,7 @@ const FLOATING_POSTER_CLASS_SHOW: string = 'playkit-floating-poster-show';
 const FLOATING_DISMISSIBLE_CONTAINER_ID: string = 'playkit-floating-dismissible-container';
 const DEFAULT_FLOATING_CONFIG: FloatingConfigObject = {
   position: 'bottom-right',
-  height: '225',
+  height: '257',
   width: '400',
   marginX: '20',
   marginY: '20',

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -55,8 +55,8 @@ class Visibility extends BasePlugin {
             container: 'TopBarRightControls',
             get: DismissibleFloatingButtonComponent,
             props: {
-              onClose: () => {
-                this._handleDismissFloating();
+              onClose: (shouldScrollToPlayer = false) => {
+                this._handleDismissFloating(shouldScrollToPlayer);
               }
             }
           }
@@ -112,10 +112,12 @@ class Visibility extends BasePlugin {
     this._floatingContainerHeight = this.config.dismissible ? `${Number(this.config.height) + DISMISSIBLE_CONTAINER_HEIGHT}` : this.config.height;
   }
 
-  _handleDismissFloating() {
+  _handleDismissFloating(shouldScrollToPlayer: boolean) {
     this._dismissed = true;
     this.player.pause();
-    this._floatingPoster.scrollIntoView();
+    if (shouldScrollToPlayer) {
+      this._floatingPoster.scrollIntoView();
+    }
     this._stopFloating();
     this.dispatchEvent(EventType.FLOATING_PLAYER_DISMISSED);
   }

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -1,0 +1,7 @@
+{
+  "en": {
+    "floating": {
+      "back_to_video": "Back to video"
+    }
+  }
+}


### PR DESCRIPTION
### Description of the Changes

- **enhancement**
    - apply new design of dismissible area
    - add new functionality: when dismissing the floating player, scroll to the main player
    - since the new dismissible area (above the player) is adding `32px` to the height of the entire floating container - calculating the total floating container height according to the `height` and `dismissible` configurations

<img width="419" alt="image" src="https://github.com/kaltura/playkit-js-visibility/assets/79077248/8098e4dd-24ee-417c-96f0-13c07b8133b0">


Solves [FEC-13662](https://kaltura.atlassian.net/browse/FEC-13662)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13662]: https://kaltura.atlassian.net/browse/FEC-13662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ