### PR TITLE
fix(FEC-13893): back to video header is missing for image preset

### DIFF
--- a/src/visibility.js
+++ b/src/visibility.js
@@ -40,7 +40,6 @@ class Visibility extends BasePlugin {
   _isInPIP: boolean = false;
   _currMousePos: {x: number, y: number} = {x: 0, y: 0};
   _throttleWait: boolean = false;
-  _floatingContainerHeight: string;
   _store: any;
   _playerSizeBeforeFloating: string;
 
@@ -165,7 +164,9 @@ class Visibility extends BasePlugin {
     Utils.Dom.setStyle(this._floatingContainer, 'margin', `${this.config.marginY}px ${this.config.marginX}px`);
     if (this.config.dismissible) {
       const dismissibleContainerEl = this._getDismissibleContainerEl();
-      dismissibleContainerEl && this._floatingContainer.prepend(dismissibleContainerEl);
+      if (dismissibleContainerEl) {
+        this._floatingContainer.prepend(dismissibleContainerEl);
+      }
     }
     if (this.config.draggable) {
       this.eventManager.listen(this._floatingContainer, 'mousedown', e => {

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -118,8 +118,16 @@ class Visibility extends BasePlugin {
     if (this.config.draggable) {
       Utils.Dom.addClassName(this._floatingContainer, FLOATING_DRAGGABLE_CLASS);
     }
+  }
 
-    this._floatingContainerHeight = this.config.dismissible ? `${Number(this.config.height) + DISMISSIBLE_CONTAINER_HEIGHT}` : this.config.height;
+  _getDismissibleContainerEl(): HTMLElement {
+    return Utils.Dom.getElementById(FLOATING_DISMISSIBLE_CONTAINER_ID);
+  }
+
+  _getFloatingContainerHeight(): string {
+    return this.config.dismissible && this._getDismissibleContainerEl()
+      ? `${Number(this.config.height) + DISMISSIBLE_CONTAINER_HEIGHT}`
+      : this.config.height;
   }
 
   _handleDismissFloating(shouldScrollToPlayer: boolean) {
@@ -152,11 +160,11 @@ class Visibility extends BasePlugin {
     this._playerSizeBeforeFloating = this._state.shell.playerSize;
     Utils.Dom.addClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
     Utils.Dom.addClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
-    Utils.Dom.setStyle(this._floatingContainer, 'height', `${this._floatingContainerHeight}px`);
+    Utils.Dom.setStyle(this._floatingContainer, 'height', `${this._getFloatingContainerHeight()}px`);
     Utils.Dom.setStyle(this._floatingContainer, 'width', this.config.width + 'px');
     Utils.Dom.setStyle(this._floatingContainer, 'margin', `${this.config.marginY}px ${this.config.marginX}px`);
     if (this.config.dismissible) {
-      const dismissibleContainerEl = Utils.Dom.getElementById(FLOATING_DISMISSIBLE_CONTAINER_ID);
+      const dismissibleContainerEl = this._getDismissibleContainerEl();
       dismissibleContainerEl && this._floatingContainer.prepend(dismissibleContainerEl);
     }
     if (this.config.draggable) {

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -56,7 +56,7 @@ class Visibility extends BasePlugin {
       ? [
           {
             label: 'dismissibleFloatingButtonComponent',
-            presets: ['Playback', 'Live', 'Error', 'Ads', 'Idle'],
+            presets: ['Playback', 'Live', 'Error', 'Ads', 'Idle', 'Img'],
             container: 'TopBarRightControls',
             get: DismissibleFloatingButtonComponent,
             props: {
@@ -157,7 +157,7 @@ class Visibility extends BasePlugin {
     Utils.Dom.setStyle(this._floatingContainer, 'margin', `${this.config.marginY}px ${this.config.marginX}px`);
     if (this.config.dismissible) {
       const dismissibleContainerEl = Utils.Dom.getElementById(FLOATING_DISMISSIBLE_CONTAINER_ID);
-      this._floatingContainer.prepend(dismissibleContainerEl);
+      dismissibleContainerEl && this._floatingContainer.prepend(dismissibleContainerEl);
     }
     if (this.config.draggable) {
       this.eventManager.listen(this._floatingContainer, 'mousedown', e => {


### PR DESCRIPTION
### Description of the Changes

**- bug fix**

**the issue:**
when playing an image, the **"Back to video"** floating header is presented as `"null"`.

**root cause:**
the `Img` preset is missing for the header component.

**solution:**
add `Img` to the presets array for the header component.
also, add a protection when prepending the header component and fix floating height calculation.

Solves FEC-13893

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
