### PR TITLE
fix(SUP-45432): [Novartis]: Floating Plugin Unresponsive

### DIFF
--- a/src/visibility.js
+++ b/src/visibility.js
@@ -42,6 +42,7 @@ class Visibility extends BasePlugin {
   _throttleWait: boolean = false;
   _store: any;
   _playerSizeBeforeFloating: string;
+  targetId: string;
 
   /**
    * The default configuration of the plugin.
@@ -140,14 +141,20 @@ class Visibility extends BasePlugin {
   }
 
   _stopFloating() {
-    Utils.Dom.removeClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
-    Utils.Dom.removeClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
-    Utils.Dom.removeAttribute(this._floatingContainer, 'style');
-    if (this.config.draggable) {
-      this.eventManager.unlisten(this._floatingContainer, 'mousedown');
-      this.eventManager.unlisten(this._floatingContainer, 'touchstart');
-      this._stopDrag();
-    }
+    const floatingPosterElements = document.querySelectorAll(`.${FLOATING_POSTER_CLASS}`);
+    const floatingContainerElements = document.querySelectorAll(`.${FLOATING_CONTAINER_CLASS}`);
+    floatingPosterElements.forEach(floatingPosterElement => {
+      Utils.Dom.removeClassName(floatingPosterElement, FLOATING_POSTER_CLASS_SHOW);
+    });
+    floatingContainerElements.forEach(floatingContainerElement => {
+      Utils.Dom.removeClassName(floatingContainerElement, FLOATING_ACTIVE_CLASS);
+      Utils.Dom.removeAttribute(floatingContainerElement, 'style');
+      if (this.config.draggable) {
+        this.eventManager.unlisten(floatingContainerElement, 'mousedown');
+        this.eventManager.unlisten(floatingContainerElement, 'touchstart');
+        this._stopDrag();
+      }
+    });
     this.dispatchEvent(EventType.FLOATING_PLAYER_STATE_CHANGED, {active: false});
     const playerSizeAfterFloating = this._state.shell.playerSize;
     if (this._playerSizeBeforeFloating !== playerSizeAfterFloating) {
@@ -156,6 +163,7 @@ class Visibility extends BasePlugin {
   }
 
   _startFloating() {
+    this.targetId = this.player.config.targetId;
     this._playerSizeBeforeFloating = this._state.shell.playerSize;
     Utils.Dom.addClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
     Utils.Dom.addClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -42,7 +42,6 @@ class Visibility extends BasePlugin {
   _throttleWait: boolean = false;
   _store: any;
   _playerSizeBeforeFloating: string;
-  targetId: string;
 
   /**
    * The default configuration of the plugin.
@@ -163,7 +162,6 @@ class Visibility extends BasePlugin {
   }
 
   _startFloating() {
-    this.targetId = this.player.config.targetId;
     this._playerSizeBeforeFloating = this._state.shell.playerSize;
     Utils.Dom.addClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
     Utils.Dom.addClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);


### PR DESCRIPTION
### Description of the Changes

**Issue:** 
When there are several players on the same page, you can only close the floating player of the first entry. if you scroll down farther and it is replaced by another floating player (another entry) you cannot close the floating player. clicking the x button won't stop it.

**Root cause:**
The floating player covers previous floating player.
When you scroll down and the next floating player appears, the floating player covers the previous one - the previous floating player remains on the window so when you hit the x button it removes only the first floating player and not all the others.

**Fix:**
When user close the floating player it will stop the floats also to the other activated floating players.

Solves [SUP-45432](https://kaltura.atlassian.net/browse/SUP-45432)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-45432]: https://kaltura.atlassian.net/browse/SUP-45432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ