### PR TITLE
fix (SUP-45432): Floating Plugin Unresponsive

### DIFF
--- a/src/visibility.js
+++ b/src/visibility.js
@@ -140,39 +140,34 @@ class Visibility extends BasePlugin {
     this.dispatchEvent(EventType.FLOATING_PLAYER_DISMISSED);
   }
 
-  _stopFloating() {
-    Utils.Dom.removeClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
-    Utils.Dom.removeClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
-    Utils.Dom.removeAttribute(this._floatingContainer, 'style');
+  _stopFloating(floatingPoster = this._floatingPoster, floatingContainer = this._floatingContainer) {
+    Utils.Dom.removeClassName(floatingPoster, FLOATING_POSTER_CLASS_SHOW);
+    Utils.Dom.removeClassName(floatingContainer, FLOATING_ACTIVE_CLASS);
+    Utils.Dom.removeAttribute(floatingContainer, 'style');
+
     if (this.config.draggable) {
-      this.eventManager.unlisten(this._floatingContainer, 'mousedown');
-      this.eventManager.unlisten(this._floatingContainer, 'touchstart');
+      this.eventManager.unlisten(floatingContainer, 'mousedown');
+      this.eventManager.unlisten(floatingContainer, 'touchstart');
       this._stopDrag();
     }
-    this.dispatchEvent(EventType.FLOATING_PLAYER_STATE_CHANGED, {active: false});
-    const playerSizeAfterFloating = this._state.shell.playerSize;
-    if (this._playerSizeBeforeFloating !== playerSizeAfterFloating) {
-      this._store.dispatch(actions.updatePlayerClientRect(this._floatingContainer.getBoundingClientRect()));
+
+    if (floatingContainer === this._floatingContainer) {
+      const playerSizeAfterFloating = this._state.shell.playerSize;
+      if (this._playerSizeBeforeFloating !== playerSizeAfterFloating) {
+        this._store.dispatch(actions.updatePlayerClientRect(floatingContainer.getBoundingClientRect()));
+      }
     }
+
+    this.dispatchEvent(EventType.FLOATING_PLAYER_STATE_CHANGED, {active: false});
   }
 
   _stopFloatingOnOtherPlayers() {
     const floatingContainers = document.getElementsByClassName(FLOATING_CONTAINER_CLASS);
     const floatingPosters = document.getElementsByClassName(FLOATING_POSTER_CLASS);
-    Array.from(floatingContainers).forEach(element => {
-      if (element !== this._floatingContainer) {
-        Utils.Dom.removeClassName(element, FLOATING_ACTIVE_CLASS);
-        Utils.Dom.removeAttribute(element, 'style');
-        if (this.config.draggable) {
-          this.eventManager.unlisten(element, 'mousedown');
-          this.eventManager.unlisten(element, 'touchstart');
-          this._stopDrag();
-        }
-      }
-    });
-    Array.from(floatingPosters).forEach(element => {
-      if (element !== this._floatingPoster) {
-        Utils.Dom.removeClassName(element, FLOATING_POSTER_CLASS_SHOW);
+
+    Array.from(floatingContainers).forEach((container, index) => {
+      if (container !== this._floatingContainer) {
+        this._stopFloating(floatingPosters[index], container);
       }
     });
   }

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -120,7 +120,8 @@ class Visibility extends BasePlugin {
   }
 
   _getDismissibleContainerEl(): HTMLElement {
-    return Utils.Dom.getElementById(FLOATING_DISMISSIBLE_CONTAINER_ID);
+    const playerContainer = Utils.Dom.getElementById(this.player.config.targetId);
+    return playerContainer.querySelector(`#${FLOATING_DISMISSIBLE_CONTAINER_ID}`);
   }
 
   _getFloatingContainerHeight(): string {
@@ -155,7 +156,29 @@ class Visibility extends BasePlugin {
     }
   }
 
+  _stopFloatingOnOtherPlayers() {
+    const floatingContainers = document.getElementsByClassName(FLOATING_CONTAINER_CLASS);
+    const floatingPosters = document.getElementsByClassName(FLOATING_POSTER_CLASS);
+    Array.from(floatingContainers).forEach(element => {
+      if (element !== this._floatingContainer) {
+        Utils.Dom.removeClassName(element, FLOATING_ACTIVE_CLASS);
+        Utils.Dom.removeAttribute(element, 'style');
+        if (this.config.draggable) {
+          this.eventManager.unlisten(element, 'mousedown');
+          this.eventManager.unlisten(element, 'touchstart');
+          this._stopDrag();
+        }
+      }
+    });
+    Array.from(floatingPosters).forEach(element => {
+      if (element !== this._floatingPoster) {
+        Utils.Dom.removeClassName(element, FLOATING_POSTER_CLASS_SHOW);
+      }
+    });
+  }
+
   _startFloating() {
+    this._stopFloatingOnOtherPlayers();
     this._playerSizeBeforeFloating = this._state.shell.playerSize;
     Utils.Dom.addClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
     Utils.Dom.addClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -140,39 +140,39 @@ class Visibility extends BasePlugin {
     this.dispatchEvent(EventType.FLOATING_PLAYER_DISMISSED);
   }
 
-  _stopFloating(floatingPoster = this._floatingPoster, floatingContainer = this._floatingContainer) {
-    Utils.Dom.removeClassName(floatingPoster, FLOATING_POSTER_CLASS_SHOW);
-    Utils.Dom.removeClassName(floatingContainer, FLOATING_ACTIVE_CLASS);
-    Utils.Dom.removeAttribute(floatingContainer, 'style');
-
+  _stopFloating() {
+    Utils.Dom.removeClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
+    Utils.Dom.removeClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
+    Utils.Dom.removeAttribute(this._floatingContainer, 'style');
     if (this.config.draggable) {
-      this.eventManager.unlisten(floatingContainer, 'mousedown');
-      this.eventManager.unlisten(floatingContainer, 'touchstart');
+      this.eventManager.unlisten(this._floatingContainer, 'mousedown');
+      this.eventManager.unlisten(this._floatingContainer, 'touchstart');
       this._stopDrag();
     }
-
-    if (floatingContainer === this._floatingContainer) {
-      this.dispatchEvent(EventType.FLOATING_PLAYER_STATE_CHANGED, {active: false});
-      const playerSizeAfterFloating = this._state.shell.playerSize;
-      if (this._playerSizeBeforeFloating !== playerSizeAfterFloating) {
-        this._store.dispatch(actions.updatePlayerClientRect(floatingContainer.getBoundingClientRect()));
-      }
+    this.dispatchEvent(EventType.FLOATING_PLAYER_STATE_CHANGED, {active: false});
+    const playerSizeAfterFloating = this._state.shell.playerSize;
+    if (this._playerSizeBeforeFloating !== playerSizeAfterFloating) {
+      this._store.dispatch(actions.updatePlayerClientRect(this._floatingContainer.getBoundingClientRect()));
     }
   }
 
   _stopFloatingOnOtherPlayers() {
     const floatingContainers = document.getElementsByClassName(FLOATING_CONTAINER_CLASS);
     const floatingPosters = document.getElementsByClassName(FLOATING_POSTER_CLASS);
-
-    Array.from(floatingContainers).forEach(container => {
-      if (container !== this._floatingContainer) {
-        this._stopFloating(null, container);
+    Array.from(floatingContainers).forEach(element => {
+      if (element !== this._floatingContainer) {
+        Utils.Dom.removeClassName(element, FLOATING_ACTIVE_CLASS);
+        Utils.Dom.removeAttribute(element, 'style');
+        if (this.config.draggable) {
+          this.eventManager.unlisten(element, 'mousedown');
+          this.eventManager.unlisten(element, 'touchstart');
+          this._stopDrag();
+        }
       }
     });
-
-    Array.from(floatingPosters).forEach(poster => {
-      if (poster !== this._floatingPoster) {
-        this._stopFloating(poster, null);
+    Array.from(floatingPosters).forEach(element => {
+      if (element !== this._floatingPoster) {
+        Utils.Dom.removeClassName(element, FLOATING_POSTER_CLASS_SHOW);
       }
     });
   }

--- a/src/visibility.js
+++ b/src/visibility.js
@@ -140,39 +140,39 @@ class Visibility extends BasePlugin {
     this.dispatchEvent(EventType.FLOATING_PLAYER_DISMISSED);
   }
 
-  _stopFloating() {
-    Utils.Dom.removeClassName(this._floatingPoster, FLOATING_POSTER_CLASS_SHOW);
-    Utils.Dom.removeClassName(this._floatingContainer, FLOATING_ACTIVE_CLASS);
-    Utils.Dom.removeAttribute(this._floatingContainer, 'style');
+  _stopFloating(floatingPoster = this._floatingPoster, floatingContainer = this._floatingContainer) {
+    Utils.Dom.removeClassName(floatingPoster, FLOATING_POSTER_CLASS_SHOW);
+    Utils.Dom.removeClassName(floatingContainer, FLOATING_ACTIVE_CLASS);
+    Utils.Dom.removeAttribute(floatingContainer, 'style');
+
     if (this.config.draggable) {
-      this.eventManager.unlisten(this._floatingContainer, 'mousedown');
-      this.eventManager.unlisten(this._floatingContainer, 'touchstart');
+      this.eventManager.unlisten(floatingContainer, 'mousedown');
+      this.eventManager.unlisten(floatingContainer, 'touchstart');
       this._stopDrag();
     }
-    this.dispatchEvent(EventType.FLOATING_PLAYER_STATE_CHANGED, {active: false});
-    const playerSizeAfterFloating = this._state.shell.playerSize;
-    if (this._playerSizeBeforeFloating !== playerSizeAfterFloating) {
-      this._store.dispatch(actions.updatePlayerClientRect(this._floatingContainer.getBoundingClientRect()));
+
+    if (floatingContainer === this._floatingContainer) {
+      this.dispatchEvent(EventType.FLOATING_PLAYER_STATE_CHANGED, {active: false});
+      const playerSizeAfterFloating = this._state.shell.playerSize;
+      if (this._playerSizeBeforeFloating !== playerSizeAfterFloating) {
+        this._store.dispatch(actions.updatePlayerClientRect(floatingContainer.getBoundingClientRect()));
+      }
     }
   }
 
   _stopFloatingOnOtherPlayers() {
     const floatingContainers = document.getElementsByClassName(FLOATING_CONTAINER_CLASS);
     const floatingPosters = document.getElementsByClassName(FLOATING_POSTER_CLASS);
-    Array.from(floatingContainers).forEach(element => {
-      if (element !== this._floatingContainer) {
-        Utils.Dom.removeClassName(element, FLOATING_ACTIVE_CLASS);
-        Utils.Dom.removeAttribute(element, 'style');
-        if (this.config.draggable) {
-          this.eventManager.unlisten(element, 'mousedown');
-          this.eventManager.unlisten(element, 'touchstart');
-          this._stopDrag();
-        }
+
+    Array.from(floatingContainers).forEach(container => {
+      if (container !== this._floatingContainer) {
+        this._stopFloating(null, container);
       }
     });
-    Array.from(floatingPosters).forEach(element => {
-      if (element !== this._floatingPoster) {
-        Utils.Dom.removeClassName(element, FLOATING_POSTER_CLASS_SHOW);
+
+    Array.from(floatingPosters).forEach(poster => {
+      if (poster !== this._floatingPoster) {
+        this._stopFloating(poster, null);
       }
     });
   }


### PR DESCRIPTION
Description of the Changes
Issue:
When there are several players on the same page, you can only close the floating player of the first entry. if you scroll down farther and it is replaced by another floating player (another entry) you cannot close the floating player. clicking the x button won't stop it.

Root cause:
The floating player covers previous floating player.
When you scroll down and the next floating player appears, the floating player covers the previous one - the previous floating player remains on the window so when you hit the x button it removes only the first floating player and not all the others.

Fix:
When floating is started, all previous floating players will be removed.

Solves [SUP-45432](https://kaltura.atlassian.net/browse/SUP-45432)

CheckLists
changes have been done against master branch, and PR does not conflict
new unit / functional tests have been added (whenever applicable)
test are passing in local environment
Travis tests are passing (or test results are not worse than on master branch :))
Docs have been updated

[SUP-45432]: https://kaltura.atlassian.net/browse/SUP-45432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ